### PR TITLE
Added non-standard "application/vnd.djvu" MIME type handling

### DIFF
--- a/orion-viewer/AndroidManifest.xml
+++ b/orion-viewer/AndroidManifest.xml
@@ -48,6 +48,7 @@
                 <data android:mimeType="image/vnd.djvu"/>
                 <data android:mimeType="image/x-djvu"/>
                 <data android:mimeType="application/djvu"/>
+                <data android:mimeType="application/vnd.djvu"/>
                 <data android:mimeType="application/pdf"/>
                 <data android:mimeType="application/vnd.ms-xpsdocument"/>
                 <data android:mimeType="application/x-cbz"/>


### PR DESCRIPTION
Launcher on Texet TB-138 uses the "application/vnd.djvu" type when sending VIEW intent for djvu files.
