### PR TITLE
Split GitHub Actions CI artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,23 @@ jobs:
         run: bash ./gradlew -b thirdparty_build.gradle downloadAndPatchDjvu downloadAndMakeMupdf
       - name: Build debug APK
         run: bash ./gradlew assembleCi --stacktrace -Porion.CIBuild=true
-      - name: Upload APK
+      - name: Upload arm7 APK
         uses: actions/upload-artifact@v2
         with:
-          name: OrionViewer-dev-${{github.run_number}}
-          path: orion-viewer/build/outputs/apk/**/*.apk
+          name: OrionViewer-arm7-dev-${{github.run_number}}.zip
+          path: orion-viewer/build/outputs/apk/arm7/ci/*.apk
+      - name: Upload arm64 APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: OrionViewer-arm64-dev-${{github.run_number}}.zip
+          path: orion-viewer/build/outputs/apk/arm64/ci/*.apk
+      - name: Upload x86 APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: OrionViewer-x86-dev-${{github.run_number}}.zip
+          path: orion-viewer/build/outputs/apk/x86/ci/*.apk
+      - name: Upload x86_64 APK
+        uses: actions/upload-artifact@v2
+        with:
+          name: OrionViewer-x86_64-dev-${{github.run_number}}.zip
+          path: orion-viewer/build/outputs/apk/x86_64/ci/*.apk                   


### PR DESCRIPTION
Each apk is still zipped  but published as separate apks (it seems it's some github restriction that artifacts are always zipped)