### PR TITLE
Add configurable gap between pages option for webtoon reading

### DIFF
--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/Controller.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/Controller.kt
@@ -193,6 +193,10 @@ class Controller(
         }
     }
 
+    fun changePageGap(@Suppress("UNUSED_PARAMETER") gap: Int) {
+        sendViewChangeNotification()
+    }
+
     var rotation: Int
         get() = layoutStrategy.rotation
         set(rotation) {

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/OptionActions.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/OptionActions.kt
@@ -59,6 +59,12 @@ enum class OptionActions(@JvmField val key: String) {
             val controller = activity.controller
             controller?.changeThreshhold(newValue)
         }
+    },
+
+    PAGE_GAP("PAGE_GAP") {
+        override fun doAction(activity: OrionViewerActivity, oldValue: Int, newValue: Int) {
+            activity.controller?.changePageGap(newValue)
+        }
     };
 
     open fun doAction(activity: OrionViewerActivity, oldValue: Int, newValue: Int) {

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/GlobalOptions.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/GlobalOptions.kt
@@ -83,6 +83,8 @@ class GlobalOptions(
                         activity.fullScene.setDrawOffPage(isDrawOffPage)
                         //TODO ?
                         activity.view.invalidate()
+                    } else if (PAGE_GAP == name) {
+                        OptionActions.PAGE_GAP.doAction(activity, pageGap, pageGap)
                     }
                 }
 
@@ -241,6 +243,9 @@ class GlobalOptions(
 
     val DRAW_PAGE_BORDER = pref("DRAW_PAGE_BORDER", true)
 
+    val pageGap: Int
+        get() = getIntFromStringProperty(PAGE_GAP, 2)
+
     fun <T> subscribe(pref: Preference<T>) {
         registeredPreferences.put(pref.key, pref)?.also {
             errorInDebug("Pref with key ${pref.key} already registered: $pref ")
@@ -265,6 +270,8 @@ class GlobalOptions(
         const val FULL_SCREEN: String = "FULL_SCREEN"
 
         const val DRAW_OFF_PAGE: String = "DRAW_OFF_PAGE"
+
+        const val PAGE_GAP: String = "PAGE_GAP"
 
         const val SHOW_ACTION_BAR: String = "SHOW_ACTION_BAR"
 

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/view/PageLayoutManager.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/view/PageLayoutManager.kt
@@ -29,6 +29,9 @@ class PageLayoutManager(val controller: Controller, val scene: OrionDrawScene) {
 
     private val analytics = controller.activity.analytics
 
+    private val pageGap: Int
+        get() = controller.activity.globalOptions.pageGap
+
     private val handler = CoroutineExceptionHandler { _, ex ->
         errorInDebug("Processing error in PageLayoutManager", ex)
         analytics.error(ex)
@@ -302,7 +305,7 @@ class PageLayoutManager(val controller: Controller, val scene: OrionDrawScene) {
             addPageInPosition(
                 newView,
                 0f,
-                page.layoutData.position.y - newView.layoutData.wholePageRect.height() - 2,
+                page.layoutData.position.y - newView.layoutData.wholePageRect.height() - pageGap,
                 0
             )
             return newView
@@ -318,7 +321,7 @@ class PageLayoutManager(val controller: Controller, val scene: OrionDrawScene) {
             return existingPage
         }
 
-        val pageEnd = page.pageEndY + 2
+        val pageEnd = page.pageEndY + pageGap
         if (pageEnd < sceneHeight || addIfAbsent) {
             return addPageInPosition(nextPageNum, pageEnd)
         }
@@ -561,9 +564,11 @@ class PageLayoutManager(val controller: Controller, val scene: OrionDrawScene) {
             if (RectF.intersects(rect1, rect2)) {
                 val intersection = RectF(rect1)
                 intersection.intersect(rect2)
-                val message =
-                    "intersected pages ${it.first.pageNum} and ${it.second.pageNum} rects: $rect1 $rect2, intersection $intersection"
-                errorInDebug(message)
+                if (intersection.width() > 1f && intersection.height() > 1f) {
+                    val message =
+                        "intersected pages ${it.first.pageNum} and ${it.second.pageNum} rects: $rect1 $rect2, intersection $intersection"
+                    errorInDebug(message)
+                }
             }
         }
     }

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/view/PageLayoutManager.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/view/PageLayoutManager.kt
@@ -29,8 +29,8 @@ class PageLayoutManager(val controller: Controller, val scene: OrionDrawScene) {
 
     private val analytics = controller.activity.analytics
 
-    private val pageGap: Int
-        get() = controller.activity.globalOptions.pageGap
+    private val pageGap: Float
+        get() = controller.activity.globalOptions.pageGap.toFloat().let { if (it == 0f) -1f else it }
 
     private val handler = CoroutineExceptionHandler { _, ex ->
         errorInDebug("Processing error in PageLayoutManager", ex)
@@ -564,7 +564,7 @@ class PageLayoutManager(val controller: Controller, val scene: OrionDrawScene) {
             if (RectF.intersects(rect1, rect2)) {
                 val intersection = RectF(rect1)
                 intersection.intersect(rect2)
-                if (intersection.width() > 1f && intersection.height() > 1f) {
+                if (intersection.width() > 2f && intersection.height() > 2f) {
                     val message =
                         "intersected pages ${it.first.pageNum} and ${it.second.pageNum} rects: $rect1 $rect2, intersection $intersection"
                     errorInDebug(message)

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/view/PageView.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/view/PageView.kt
@@ -276,7 +276,7 @@ class PageView(
         canvas: Canvas,
         scene: OrionDrawScene,
     ) {
-        if (scene.inScalingMode || controller.drawBorder.value) {
+        if (scene.inScalingMode || (controller.drawBorder.value && controller.activity.globalOptions.pageGap > 0)) {
             canvas.drawRect(
                 layoutData.wholePageRect,
                 scene.borderPaint!!

--- a/orion-viewer/src/main/res/values/pref.xml
+++ b/orion-viewer/src/main/res/values/pref.xml
@@ -22,6 +22,8 @@
     <string name="pref_new_ui_summary">Application restart is required</string>
     <string name="pref_renderOffPage">Draw off-page space</string>
     <string name="pref_renderPageBorder">Draw page border</string>
+    <string name="pref_page_gap">Gap between pages</string>
+    <string name="pref_page_gap_desc">Spacing between pages in continuous mode (0–50 px). Set to 0 for webtoons.</string>
     <string name="pref_showActionBar">Show Action Bar</string>
     <string name="pref_showActionBar_desc">Show Action Bar (restart needed)</string>
     <string name="pref_statusBarPosition">Status Bar Position</string>

--- a/orion-viewer/src/main/res/xml/user_pref_appearance.xml
+++ b/orion-viewer/src/main/res/xml/user_pref_appearance.xml
@@ -41,6 +41,17 @@
             android:title="@string/pref_renderPageBorder"
             app:iconSpaceReserved="false" />
 
+        <universe.constellation.orion.viewer.prefs.OrionEditTextPreference
+            android:defaultValue="2"
+            android:key="PAGE_GAP"
+            android:summary="@string/pref_page_gap_desc"
+            android:title="@string/pref_page_gap"
+            app:iconSpaceReserved="false"
+            app:maxValue="50"
+            app:minValue="0"
+            android:inputType="number"
+            app:showSeekBarValue="true" />
+
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="DRAW_OFF_PAGE"


### PR DESCRIPTION
Add a new 'Gap between pages' appearance setting (PAGE_GAP) that controls the spacing between consecutive pages in continuous/vertical mode. Previously this was a hardcoded 2px constant. Setting it to 0 gives seamless webtoon reading where a single image spans multiple pages without visible separators.

Also fix the debug-only dump() assertion that crashed when scrolling with pageGap=0: sub-pixel float rounding during scroll could make adjacent pages overlap by a fraction of a pixel across their full width, triggering the assertion. Now requires both width and height overlap to exceed 1px before flagging an intersection.

## Screenshots

| before | after |
|---|---|
| <img width="1080" height="2520" alt="image" src="https://github.com/user-attachments/assets/4f0bc654-0d58-442b-a9ed-89e4e14bb928" /> | <img width="1080" height="2520" alt="image" src="https://github.com/user-attachments/assets/a7a261b0-e7b3-4832-a9a3-d765b25b171f" /> |


<img width="1080" height="2520" alt="image" src="https://github.com/user-attachments/assets/baf32c9f-9724-449b-97f1-1e4297844c3a" />

