### PR TITLE
Correct dictionary dialog title

### DIFF
--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/OrionBookPreferencesX.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/OrionBookPreferencesX.kt
@@ -81,7 +81,7 @@ class OrionBookPreferencesFragment : DSLPreferenceFragment() {
                     key = DICTIONARY.prefKey
                     title = pref_dictionary.stringRes
                     summary = pref_dictionary_desc.stringRes
-                    dialogTitle = pref_screen_orientation.stringRes
+                    dialogTitle = pref_dictionary.stringRes
 
                     if (!isGeneral) {
                         setDefaultValue("DEFAULT")


### PR DESCRIPTION
This fixes #160, where in the settings under `General > Default Book Settings > Dictionary`, the dialog select title says "Screen orientation" instead of the expected "Dictionary". The issue also occurs in the per-book settings, and since the same logic is used, the issue is fixed there as well.

## Before

<img width="316" height="606" alt="image" src="https://github.com/user-attachments/assets/1fb38747-491e-45f1-9f79-f40106fe94a2" />


## After

<img width="312" height="605" alt="image" src="https://github.com/user-attachments/assets/2083de7f-80ff-47cf-9787-e0bb39c73a2a" />
