### PR TITLE
Feature: Save contents of the search box between searches

### DIFF
--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -62,8 +62,6 @@ public class SearchDialog extends DialogFragment {
 
     private EditText searchField;
 
-    private StringBuilder savedSearchText;
-
     private final SearchResultRenderer lastSearchResultRenderer = new SearchResultRenderer();
 
     private static final int ALPHA = 150;
@@ -104,11 +102,9 @@ public class SearchDialog extends DialogFragment {
         int textColor = searchField.getTextColors().getDefaultColor();
         searchField.setTextColor(ColorUtil.transformColor(textColor, orionViewerActivity.getFullScene().getColorStuff().getColorMatrix()));
 
-        savedSearchText = orionViewerActivity.getOrionApplication().getTempOptions().savedSearchText;
-
         boolean preserveSearches = orionViewerActivity.getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue();
         if (preserveSearches) {
-            searchField.setText(savedSearchText);
+            searchField.setText(orionViewerActivity.getOrionApplication().getTempOptions().savedSearchText);
             searchField.selectAll();
         }
         
@@ -238,9 +234,10 @@ public class SearchDialog extends DialogFragment {
         String newSearch = searchField.getText().toString();
         lastDirectionOnSearch = direction;
         if (newSearch.isEmpty()) {
-            requireOrionActivity().showAlert(R.string.msg_error, R.string.msg_specify_keyword_for_search);
+            OrionViewerActivity orionViewerActivity = requireOrionActivity();
+            orionViewerActivity.showAlert(R.string.msg_error, R.string.msg_specify_keyword_for_search);
 
-            savedSearchText.setLength(0);
+            orionViewerActivity.getOrionApplication().getTempOptions().savedSearchText = "";
             return;
         }
 
@@ -275,11 +272,13 @@ public class SearchDialog extends DialogFragment {
             destroyLastPage();
             myTask.go(newSearch, direction, page, -1, (SimpleLayoutStrategy) controller.getLayoutStrategy());
 
-            savedSearchText.setLength(0);
+            OrionViewerActivity orionViewerActivity = requireOrionActivity();
 
-            boolean preserveSearches = requireOrionActivity().getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue();
+            boolean preserveSearches = orionViewerActivity.getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue();
             if (preserveSearches) {
-                savedSearchText.append(searchField.getText());
+                orionViewerActivity.getOrionApplication().getTempOptions().savedSearchText = searchField.getText().toString();
+            } else {
+                orionViewerActivity.getOrionApplication().getTempOptions().savedSearchText = "";
             }
         } else {
             SubBatch subBatch = screens.get(lastPosition);

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -62,7 +62,7 @@ public class SearchDialog extends DialogFragment {
 
     private EditText searchField;
 
-    private static String previousSearch = "";
+    private StringBuilder savedSearchText;
 
     private final SearchResultRenderer lastSearchResultRenderer = new SearchResultRenderer();
 
@@ -104,12 +104,12 @@ public class SearchDialog extends DialogFragment {
         int textColor = searchField.getTextColors().getDefaultColor();
         searchField.setTextColor(ColorUtil.transformColor(textColor, orionViewerActivity.getFullScene().getColorStuff().getColorMatrix()));
 
-        boolean preserveSearches = Boolean.TRUE.equals(orionViewerActivity.getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue());
+        savedSearchText = orionViewerActivity.getOrionApplication().getTempOptions().savedSearchText;
+
+        boolean preserveSearches = orionViewerActivity.getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue();
         if (preserveSearches) {
-            searchField.setText(previousSearch);
+            searchField.setText(savedSearchText);
             searchField.selectAll();
-        } else {
-            previousSearch = "";
         }
         
         searchField.setOnEditorActionListener((v, actionId, event) -> {
@@ -239,8 +239,8 @@ public class SearchDialog extends DialogFragment {
         lastDirectionOnSearch = direction;
         if (newSearch.isEmpty()) {
             requireOrionActivity().showAlert(R.string.msg_error, R.string.msg_specify_keyword_for_search);
-            
-            previousSearch = "";
+
+            savedSearchText.setLength(0);
             return;
         }
 
@@ -275,7 +275,12 @@ public class SearchDialog extends DialogFragment {
             destroyLastPage();
             myTask.go(newSearch, direction, page, -1, (SimpleLayoutStrategy) controller.getLayoutStrategy());
 
-            previousSearch = searchField.getText().toString();
+            savedSearchText.setLength(0);
+
+            boolean preserveSearches = requireOrionActivity().getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue();
+            if (preserveSearches) {
+                savedSearchText.append(searchField.getText());
+            }
         } else {
             SubBatch subBatch = screens.get(lastPosition);
             drawBatch(subBatch, controller);

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -12,11 +12,13 @@ import android.graphics.RectF;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
@@ -60,7 +62,7 @@ public class SearchDialog extends DialogFragment {
 
     private EditText searchField;
 
-    private static StringBuffer previousSearch = new StringBuffer();
+    private static final StringBuffer previousSearch = new StringBuffer();
 
     private final SearchResultRenderer lastSearchResultRenderer = new SearchResultRenderer();
 
@@ -102,6 +104,26 @@ public class SearchDialog extends DialogFragment {
         int textColor = searchField.getTextColors().getDefaultColor();
         searchField.setTextColor(ColorUtil.transformColor(textColor, orionViewerActivity.getFullScene().getColorStuff().getColorMatrix()));
         searchField.setText(previousSearch);
+        
+        searchField.setOnEditorActionListener((v, actionId, event) -> {
+            boolean isEnter =
+                actionId == EditorInfo.IME_ACTION_SEARCH ||
+                actionId == EditorInfo.IME_ACTION_GO ||
+                actionId == EditorInfo.IME_ACTION_DONE ||
+                actionId == EditorInfo.IME_ACTION_SEND ||
+                actionId == EditorInfo.IME_ACTION_NEXT;
+
+            boolean isKeyEnter =
+                event != null &&
+                event.getAction() == KeyEvent.ACTION_DOWN &&
+                event.getKeyCode() == KeyEvent.KEYCODE_ENTER;
+
+            if (isEnter || isKeyEnter) {
+                doSearch(searchField, controller.getCurrentPage(), 1, controller, previousSearch);
+                return true;
+            }
+            return false;
+        });
 
         android.widget.ImageButton searchNext = dialog.findViewById(R.id.searchNext);
         searchNext.getBackground().setAlpha(ALPHA);

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -124,7 +124,7 @@ public class SearchDialog extends DialogFragment {
                 (event.getKeyCode() == KeyEvent.KEYCODE_ENTER || event.getKeyCode() == KeyEvent.KEYCODE_NUMPAD_ENTER);
 
             if (isEnter || isKeyEnter) {
-                doSearch(searchField, controller.getCurrentPage(), 1, controller);
+                doSearch(searchField, controller.getCurrentPage(), +1, controller);
                 return true;
             }
             return false;

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -240,6 +240,8 @@ public class SearchDialog extends DialogFragment {
         lastDirectionOnSearch = direction;
         if (newSearch.isEmpty()) {
             requireOrionActivity().showAlert(R.string.msg_error, R.string.msg_specify_keyword_for_search);
+            
+            searchText.setLength(0);
             return;
         }
 

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -107,6 +107,8 @@ public class SearchDialog extends DialogFragment {
         boolean preserveSearches = Boolean.TRUE.equals(orionViewerActivity.getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue());
         if (preserveSearches) {
             searchField.setText(previousSearch);
+        } else {
+            previousSearch.setLength(0);
         }
         
         searchField.setOnEditorActionListener((v, actionId, event) -> {
@@ -123,7 +125,7 @@ public class SearchDialog extends DialogFragment {
                 event.getKeyCode() == KeyEvent.KEYCODE_ENTER;
 
             if (isEnter || isKeyEnter) {
-                doSearch(searchField, controller.getCurrentPage(), 1, controller, preserveSearches, previousSearch);
+                doSearch(searchField, controller.getCurrentPage(), 1, controller, previousSearch);
                 return true;
             }
             return false;
@@ -131,11 +133,11 @@ public class SearchDialog extends DialogFragment {
 
         android.widget.ImageButton searchNext = dialog.findViewById(R.id.searchNext);
         searchNext.getBackground().setAlpha(ALPHA);
-        searchNext.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), +1, controller, preserveSearches, previousSearch));
+        searchNext.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), +1, controller, previousSearch));
 
         android.widget.ImageButton searchPrev = dialog.findViewById(R.id.searchPrev);
         searchPrev.getBackground().setAlpha(ALPHA);
-        searchPrev.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), -1, controller, preserveSearches, previousSearch));
+        searchPrev.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), -1, controller, previousSearch));
 
         OrionDrawScene view = orionViewerActivity.getView();
         view.addTask(lastSearchResultRenderer);
@@ -229,13 +231,7 @@ public class SearchDialog extends DialogFragment {
         }
     }
 
-    private void doSearch(
-            EditText searchField,
-            int page,
-            int direction,
-            Controller controller,
-            boolean preserveSearches,
-            StringBuffer newSearchText) {
+    private void doSearch(EditText searchField, int page, int direction, Controller controller, StringBuffer searchText) {
         InputMethodManager inputManager = (InputMethodManager) requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
         inputManager.hideSoftInputFromWindow(searchField.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
 
@@ -278,10 +274,8 @@ public class SearchDialog extends DialogFragment {
             destroyLastPage();
             myTask.go(newSearch, direction, page, -1, (SimpleLayoutStrategy) controller.getLayoutStrategy());
             
-            newSearchText.setLength(0);
-            if (preserveSearches) {
-                newSearchText.append(searchField.getText().toString());
-            }
+            searchText.setLength(0);
+            searchText.append(searchField.getText().toString());
         } else {
             SubBatch subBatch = screens.get(lastPosition);
             drawBatch(subBatch, controller);

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -62,7 +62,7 @@ public class SearchDialog extends DialogFragment {
 
     private EditText searchField;
 
-    private static final StringBuffer previousSearch = new StringBuffer();
+    private static String previousSearch = "";
 
     private final SearchResultRenderer lastSearchResultRenderer = new SearchResultRenderer();
 
@@ -108,7 +108,7 @@ public class SearchDialog extends DialogFragment {
         if (preserveSearches) {
             searchField.setText(previousSearch);
         } else {
-            previousSearch.setLength(0);
+            previousSearch = "";
         }
         
         searchField.setOnEditorActionListener((v, actionId, event) -> {
@@ -125,7 +125,7 @@ public class SearchDialog extends DialogFragment {
                 event.getKeyCode() == KeyEvent.KEYCODE_ENTER;
 
             if (isEnter || isKeyEnter) {
-                doSearch(searchField, controller.getCurrentPage(), 1, controller, previousSearch);
+                doSearch(searchField, controller.getCurrentPage(), 1, controller);
                 return true;
             }
             return false;
@@ -133,11 +133,11 @@ public class SearchDialog extends DialogFragment {
 
         android.widget.ImageButton searchNext = dialog.findViewById(R.id.searchNext);
         searchNext.getBackground().setAlpha(ALPHA);
-        searchNext.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), +1, controller, previousSearch));
+        searchNext.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), +1, controller));
 
         android.widget.ImageButton searchPrev = dialog.findViewById(R.id.searchPrev);
         searchPrev.getBackground().setAlpha(ALPHA);
-        searchPrev.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), -1, controller, previousSearch));
+        searchPrev.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), -1, controller));
 
         OrionDrawScene view = orionViewerActivity.getView();
         view.addTask(lastSearchResultRenderer);
@@ -231,7 +231,7 @@ public class SearchDialog extends DialogFragment {
         }
     }
 
-    private void doSearch(EditText searchField, int page, int direction, Controller controller, StringBuffer searchText) {
+    private void doSearch(EditText searchField, int page, int direction, Controller controller) {
         InputMethodManager inputManager = (InputMethodManager) requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
         inputManager.hideSoftInputFromWindow(searchField.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
 
@@ -241,7 +241,7 @@ public class SearchDialog extends DialogFragment {
         if (newSearch.isEmpty()) {
             requireOrionActivity().showAlert(R.string.msg_error, R.string.msg_specify_keyword_for_search);
             
-            searchText.setLength(0);
+            previousSearch = "";
             return;
         }
 
@@ -275,9 +275,8 @@ public class SearchDialog extends DialogFragment {
             log("Real search for " + page);
             destroyLastPage();
             myTask.go(newSearch, direction, page, -1, (SimpleLayoutStrategy) controller.getLayoutStrategy());
-            
-            searchText.setLength(0);
-            searchText.append(searchField.getText().toString());
+
+            previousSearch = searchField.getText().toString();
         } else {
             SubBatch subBatch = screens.get(lastPosition);
             drawBatch(subBatch, controller);

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -103,7 +103,11 @@ public class SearchDialog extends DialogFragment {
         searchField.getBackground().setAlpha(ALPHA);
         int textColor = searchField.getTextColors().getDefaultColor();
         searchField.setTextColor(ColorUtil.transformColor(textColor, orionViewerActivity.getFullScene().getColorStuff().getColorMatrix()));
-        searchField.setText(previousSearch);
+
+        boolean preserveSearches = Boolean.TRUE.equals(orionViewerActivity.getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue());
+        if (preserveSearches) {
+            searchField.setText(previousSearch);
+        }
         
         searchField.setOnEditorActionListener((v, actionId, event) -> {
             boolean isEnter =
@@ -119,7 +123,7 @@ public class SearchDialog extends DialogFragment {
                 event.getKeyCode() == KeyEvent.KEYCODE_ENTER;
 
             if (isEnter || isKeyEnter) {
-                doSearch(searchField, controller.getCurrentPage(), 1, controller, previousSearch);
+                doSearch(searchField, controller.getCurrentPage(), 1, controller, preserveSearches, previousSearch);
                 return true;
             }
             return false;
@@ -127,11 +131,11 @@ public class SearchDialog extends DialogFragment {
 
         android.widget.ImageButton searchNext = dialog.findViewById(R.id.searchNext);
         searchNext.getBackground().setAlpha(ALPHA);
-        searchNext.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), +1, controller, previousSearch));
+        searchNext.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), +1, controller, preserveSearches, previousSearch));
 
         android.widget.ImageButton searchPrev = dialog.findViewById(R.id.searchPrev);
         searchPrev.getBackground().setAlpha(ALPHA);
-        searchPrev.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), -1, controller, previousSearch));
+        searchPrev.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), -1, controller, preserveSearches, previousSearch));
 
         OrionDrawScene view = orionViewerActivity.getView();
         view.addTask(lastSearchResultRenderer);
@@ -225,7 +229,13 @@ public class SearchDialog extends DialogFragment {
         }
     }
 
-    private void doSearch(EditText searchField, int page, int direction, Controller controller, StringBuffer newSearchText) {
+    private void doSearch(
+            EditText searchField,
+            int page,
+            int direction,
+            Controller controller,
+            boolean preserveSearches,
+            StringBuffer newSearchText) {
         InputMethodManager inputManager = (InputMethodManager) requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
         inputManager.hideSoftInputFromWindow(searchField.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
 
@@ -269,7 +279,9 @@ public class SearchDialog extends DialogFragment {
             myTask.go(newSearch, direction, page, -1, (SimpleLayoutStrategy) controller.getLayoutStrategy());
             
             newSearchText.setLength(0);
-            newSearchText.append(searchField.getText().toString());
+            if (preserveSearches) {
+                newSearchText.append(searchField.getText().toString());
+            }
         } else {
             SubBatch subBatch = screens.get(lastPosition);
             drawBatch(subBatch, controller);

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -107,6 +107,7 @@ public class SearchDialog extends DialogFragment {
         boolean preserveSearches = Boolean.TRUE.equals(orionViewerActivity.getGlobalOptions().getPRESERVE_SEARCH_TEXT().getValue());
         if (preserveSearches) {
             searchField.setText(previousSearch);
+            searchField.selectAll();
         } else {
             previousSearch = "";
         }

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -60,6 +60,8 @@ public class SearchDialog extends DialogFragment {
 
     private EditText searchField;
 
+    private static StringBuffer previousSearch = new StringBuffer();
+
     private final SearchResultRenderer lastSearchResultRenderer = new SearchResultRenderer();
 
     private static final int ALPHA = 150;
@@ -99,14 +101,15 @@ public class SearchDialog extends DialogFragment {
         searchField.getBackground().setAlpha(ALPHA);
         int textColor = searchField.getTextColors().getDefaultColor();
         searchField.setTextColor(ColorUtil.transformColor(textColor, orionViewerActivity.getFullScene().getColorStuff().getColorMatrix()));
+        searchField.setText(previousSearch);
 
         android.widget.ImageButton searchNext = dialog.findViewById(R.id.searchNext);
         searchNext.getBackground().setAlpha(ALPHA);
-        searchNext.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), +1, controller));
+        searchNext.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), +1, controller, previousSearch));
 
         android.widget.ImageButton searchPrev = dialog.findViewById(R.id.searchPrev);
         searchPrev.getBackground().setAlpha(ALPHA);
-        searchPrev.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), -1, controller));
+        searchPrev.setOnClickListener(v -> doSearch(searchField, controller.getCurrentPage(), -1, controller, previousSearch));
 
         OrionDrawScene view = orionViewerActivity.getView();
         view.addTask(lastSearchResultRenderer);
@@ -200,7 +203,7 @@ public class SearchDialog extends DialogFragment {
         }
     }
 
-    private void doSearch(EditText searchField, int page, int direction, Controller controller) {
+    private void doSearch(EditText searchField, int page, int direction, Controller controller, StringBuffer newSearchText) {
         InputMethodManager inputManager = (InputMethodManager) requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE);
         inputManager.hideSoftInputFromWindow(searchField.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
 
@@ -242,6 +245,9 @@ public class SearchDialog extends DialogFragment {
             log("Real search for " + page);
             destroyLastPage();
             myTask.go(newSearch, direction, page, -1, (SimpleLayoutStrategy) controller.getLayoutStrategy());
+            
+            newSearchText.setLength(0);
+            newSearchText.append(searchField.getText().toString());
         } else {
             SubBatch subBatch = screens.get(lastPosition);
             drawBatch(subBatch, controller);

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/dialog/SearchDialog.java
@@ -115,14 +115,12 @@ public class SearchDialog extends DialogFragment {
             boolean isEnter =
                 actionId == EditorInfo.IME_ACTION_SEARCH ||
                 actionId == EditorInfo.IME_ACTION_GO ||
-                actionId == EditorInfo.IME_ACTION_DONE ||
-                actionId == EditorInfo.IME_ACTION_SEND ||
-                actionId == EditorInfo.IME_ACTION_NEXT;
+                actionId == EditorInfo.IME_ACTION_DONE;
 
             boolean isKeyEnter =
                 event != null &&
                 event.getAction() == KeyEvent.ACTION_DOWN &&
-                event.getKeyCode() == KeyEvent.KEYCODE_ENTER;
+                (event.getKeyCode() == KeyEvent.KEYCODE_ENTER || event.getKeyCode() == KeyEvent.KEYCODE_NUMPAD_ENTER);
 
             if (isEnter || isKeyEnter) {
                 doSearch(searchField, controller.getCurrentPage(), 1, controller);

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/GlobalOptions.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/GlobalOptions.kt
@@ -241,6 +241,8 @@ class GlobalOptions(
 
     val DRAW_PAGE_BORDER = pref("DRAW_PAGE_BORDER", true)
 
+    val PRESERVE_SEARCH_TEXT = pref("PRESERVE_SEARCH_TEXT", true)
+
     fun <T> subscribe(pref: Preference<T>) {
         registeredPreferences.put(pref.key, pref)?.also {
             errorInDebug("Pref with key ${pref.key} already registered: $pref ")

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/OrionApplication.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/OrionApplication.kt
@@ -165,7 +165,7 @@ class OrionApplication : Application(), DefaultLifecycleObserver {
     fun onNewBook(fileName: String) {
         tempOptions = TemporaryOptions().also {
             it.openedFile = fileName
-            it.savedSearchText = StringBuilder()
+            it.savedSearchText = String()
         }
     }
 

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/OrionApplication.kt
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/OrionApplication.kt
@@ -163,7 +163,10 @@ class OrionApplication : Application(), DefaultLifecycleObserver {
     }
 
     fun onNewBook(fileName: String) {
-        tempOptions = TemporaryOptions().also { it.openedFile = fileName }
+        tempOptions = TemporaryOptions().also {
+            it.openedFile = fileName
+            it.savedSearchText = StringBuilder()
+        }
     }
 
 

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/TemporaryOptions.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/TemporaryOptions.java
@@ -33,6 +33,6 @@ public class TemporaryOptions {
 
     public String openedFile;
 
-    public StringBuilder savedSearchText;
+    public String savedSearchText;
 }
 

--- a/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/TemporaryOptions.java
+++ b/orion-viewer/src/main/java/universe/constellation/orion/viewer/prefs/TemporaryOptions.java
@@ -32,5 +32,7 @@ public class TemporaryOptions {
     public Long bookId;
 
     public String openedFile;
+
+    public StringBuilder savedSearchText;
 }
 

--- a/orion-viewer/src/main/res/layout/search_dialog_int.xml
+++ b/orion-viewer/src/main/res/layout/search_dialog_int.xml
@@ -14,6 +14,7 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:inputType="text"
+        android:imeOptions="actionSearch"
         android:minWidth="200dp" />
 
     <ImageButton

--- a/orion-viewer/src/main/res/values/pref.xml
+++ b/orion-viewer/src/main/res/values/pref.xml
@@ -46,6 +46,8 @@
     <string name="pref_close_page_option_dialog_on_apply">Close page option dialog on apply button click</string>
     <string name="pref_swap_prev_next_keys">Swap prev/next keys</string>
     <string name="pref_swap_prev_next_keys_on_90_degree_rotation">Swap prev/next keys in landscape mode</string>
+    <string name="pref_preserve_search_text">Preserve search box contents</string>
+    <string name="pref_preserve_search_text_desc">Searched text is saved between searches</string>
     <string name="pref_dictionary">Dictionary</string>
     <string name="pref_dictionary_desc">Dictionary: %s</string>
     <string name="pref_e_ink_optimization">E-ink</string>

--- a/orion-viewer/src/main/res/values/pref.xml
+++ b/orion-viewer/src/main/res/values/pref.xml
@@ -46,8 +46,8 @@
     <string name="pref_close_page_option_dialog_on_apply">Close page option dialog on apply button click</string>
     <string name="pref_swap_prev_next_keys">Swap prev/next keys</string>
     <string name="pref_swap_prev_next_keys_on_90_degree_rotation">Swap prev/next keys in landscape mode</string>
-    <string name="pref_preserve_search_text">Preserve search box contents</string>
-    <string name="pref_preserve_search_text_desc">Searched text is saved between searches</string>
+    <string name="pref_preserve_search_text">Preserve search box query</string>
+    <string name="pref_preserve_search_text_desc">Keep previous query in the search box</string>
     <string name="pref_dictionary">Dictionary</string>
     <string name="pref_dictionary_desc">Dictionary: %s</string>
     <string name="pref_e_ink_optimization">E-ink</string>

--- a/orion-viewer/src/main/res/xml/user_pref_controls.xml
+++ b/orion-viewer/src/main/res/xml/user_pref_controls.xml
@@ -72,6 +72,13 @@
             android:summary="@string/pref_swap_prev_next_keys_on_90_degree_rotation"
             android:title="@string/pref_swap_prev_next_keys"
             app:iconSpaceReserved="false" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="PRESERVE_SEARCH_TEXT"
+            android:summary="@string/pref_preserve_search_text_desc"
+            android:title="@string/pref_preserve_search_text"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
While doing some testing on my EPUB fork, I found if you close out of the search box, the searched text does not get preserved; behavior inconsistent from most applications I've used. This means if you want to search for the same string of text multiple times (either between closing the search box or across different documents), you must retype out the search every time you open the search box.

This PR introduces this search-saving functionality, which can be disabled in the settings if desired.

Additionally, I changed it so pressing the enter button in the search box performs the same action as hitting the `>` next search button, as currently it doesn't do anything other than close the keyboard.

### Before
[before.webm](https://github.com/user-attachments/assets/20f93225-0894-46ee-865a-305edb5e4128)

### After
[after.webm](https://github.com/user-attachments/assets/3ae3a806-079a-4f14-8b35-4083712c0425)

Setting toggle is under `Application Settings > Controls and Behavior > Default Behavior`, and is enabled by default:

<img width="289" height="556" alt="Setting" src="https://github.com/user-attachments/assets/df1cff15-5175-4901-b3b6-70ac1220c9cb" />

Some notes:

- The search is common across all documents: I think this is simpler (both for UI/programmatically) and more useful than per-document searches
- There is an edge case that I don't particularly care about fixing: A search is performed, then search save setting is disabled, then no other searches are performed (if another is, this issue doesn't apply), then the save setting is re-enabled, the original saved search still shows up. I think the cost to readability from the extra logic required to track the state of the preference change isn't worth it to fix this fringe case.